### PR TITLE
헤로쿠 추가 설정 파일

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: java $JAVA_OPTS -Dserver.port=$PORT -Dspring.profiles.active=default -jar build/libs/get-in-line-0.1.3-SNAPSHOT.jar


### PR DESCRIPTION
`Procfile`을 직접 작성해줘야 에러가 나지 않는다고 한다.