### PR TITLE
헤로쿠 - DB 설정 추가

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: java $JAVA_OPTS -Dserver.port=$PORT -Dspring.profiles.active=default -jar build/libs/get-in-line-0.1.3-SNAPSHOT.jar
+web: java $JAVA_OPTS -Dserver.port=$PORT -Dspring.profiles.active=alpha -jar build/libs/get-in-line-0.1.3-SNAPSHOT.jar

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -26,3 +26,13 @@ spring.sql.init.mode=always
 
 # API
 spring.data.rest.base-path=/api
+
+#---
+
+spring.config.activate.on-profile=alpha
+
+spring.jpa.hibernate.ddl-auto=validate
+spring.datasource.url=jdbc:mysql://b2fe33867c5eb6:3bf314b4@us-cdbr-east-04.cleardb.com/heroku_74931efe97faf8e?reconnect=true
+spring.datasource.username=root
+spring.datasource.password=
+spring.sql.init.mode=never


### PR DESCRIPTION
헤로쿠 clearDB 설정 추가하고 관련 옵션 수정
clearDB id 채번 규칙의 문제로 ddl 옵션은 모두 끄고, 데이터 이전은 직접 수행