### PR TITLE
[헤로쿠] MySQL DB AddOn 을 ClearDB -> JawsDB 로 이관

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -35,8 +35,6 @@ spring.devtools.restart.quiet-period=800ms
 
 spring.config.activate.on-profile=alpha
 
-spring.jpa.hibernate.ddl-auto=validate
-spring.datasource.url=jdbc:mysql://b2fe33867c5eb6:3bf314b4@us-cdbr-east-04.cleardb.com/heroku_74931efe97faf8e?reconnect=true
-spring.datasource.username=root
-spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=create
+spring.datasource.url=${JAWSDB_URL}
 spring.sql.init.mode=never


### PR DESCRIPTION
이 작업은 유료화되는 헤로쿠 애드온 ClearDB를 무료인 JawsDB로 변경하는 헤로쿠 작업에 대응합니다.

This closes #37 