### PR TITLE
[헤로쿠] MySQL DB AddOn 을 ClearDB -> JawsDB 로 이관: 테스트 데이터 오픈

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -35,6 +35,4 @@ spring.devtools.restart.quiet-period=800ms
 
 spring.config.activate.on-profile=alpha
 
-spring.jpa.hibernate.ddl-auto=create
 spring.datasource.url=${JAWSDB_URL}
-spring.sql.init.mode=never


### PR DESCRIPTION
이 작업은 헤로쿠 데모 사이트에서 좀 더 그럴싸한 화면을 볼 수 있도록,
테스트 데이터를 오픈합니다.

work item: #37 